### PR TITLE
Lennard Jones and periodicity

### DIFF
--- a/src/pairwise.c
+++ b/src/pairwise.c
@@ -5,7 +5,21 @@
 #include <morpho/veneer.h>
 #include <morpho/functional.h>
 
+#include <math.h>
 #include "pairwise.h"
+
+/** Calculate the difference of two vectors assuming a periodicity length `box` in each dimension */
+void functional_vecsub_periodic(unsigned int n, double *a, double *b, double box, double *out) {
+    for (unsigned int i=0; i<n; i++) {
+        out[i]=a[i]-b[i];
+        if (out[i]>0.5*box) {
+            out[i] = fmod(out[i] + box/2, box) - box/2;
+        }
+        else if (out[i]<-0.5*box) {
+            out[i] = fmod(out[i] - box/2, box) + box/2;
+        }
+    }
+}
 
 /* ----------------------------------------------
  * Some common pairwise potentials
@@ -98,12 +112,67 @@ MORPHO_METHOD(PAIRWISE_VALUE_METHOD, Hertzian_value, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(PAIRWISE_DERIVATIVE_METHOD, Hertzian_deriv, BUILTIN_FLAGSEMPTY)
 MORPHO_ENDCLASS
 
+value lj_sigmaproperty;
+
+value LennardJones_init(vm *v, int nargs, value *args) {
+    objectinstance *self = MORPHO_GETINSTANCE(MORPHO_SELF(args));
+
+    if (nargs>0 && MORPHO_ISNUMBER(MORPHO_GETARG(args, 0))) {
+        objectinstance_setproperty(self, lj_sigmaproperty, MORPHO_GETARG(args, 0));
+    } else {
+        printf("Error here!\n");
+        morpho_runtimeerror(v, PAIRWISE_PRP);
+    }
+
+    return MORPHO_NIL;
+}
+
+bool lennardjones_getsigma(value obj, double *sigma) {
+    value val; 
+    return (objectinstance_getproperty(MORPHO_GETINSTANCE(obj), lj_sigmaproperty, &val) && 
+            morpho_valuetofloat(val, sigma));
+}
+
+value LennardJones_value(vm *v, int nargs, value *args) { 
+    value out = MORPHO_NIL; 
+    if (nargs==1) {
+        double sigma, r, val;
+        if (lennardjones_getsigma(MORPHO_SELF(args), &sigma) &&
+            morpho_valuetofloat(MORPHO_GETARG(args, 0), &r)) {
+            val = 4*(pow((sigma/r), 12) - pow((sigma/r), 6));
+            out = MORPHO_FLOAT(val) ;
+        } 
+    }
+    return out; 
+}
+
+value LennardJones_deriv(vm *v, int nargs, value *args) { 
+    value out = MORPHO_NIL; 
+    if (nargs==1) {
+        double sigma, r, val;
+        if (lennardjones_getsigma(MORPHO_SELF(args), &sigma) &&
+            morpho_valuetofloat(MORPHO_GETARG(args, 0), &r)){
+            val = -24 * (2 * pow((sigma/r),12) - pow((sigma/r),6)) / r;
+            out = MORPHO_FLOAT(val);
+        } 
+    }
+    return out; 
+}
+
+MORPHO_BEGINCLASS(LennardJones)
+MORPHO_METHOD(MORPHO_INITIALIZER_METHOD, LennardJones_init, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(PAIRWISE_VALUE_METHOD, LennardJones_value, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(PAIRWISE_DERIVATIVE_METHOD, LennardJones_deriv, BUILTIN_FLAGSEMPTY)
+MORPHO_ENDCLASS
+
+
 /* ----------------------------------------------
  * Pairwise class
  * ---------------------------------------------- */
 
 value pairwise_potentialproperty;
 value pairwise_cutoffproperty;
+value pairwise_periodicproperty;
 
 value pairwise_valuemethod; 
 value pairwise_derivativemethod; 
@@ -114,15 +183,20 @@ typedef struct {
     value derivmethod; 
     bool cutoff; 
     double cutoffdist; 
+    bool periodic; 
+    double box; 
 } pairwiseref;
 
 /** Prepares the reference structure from the object's properties */
 bool pairwise_prepareref(objectinstance *self, objectmesh *mesh, grade g, objectselection *sel, pairwiseref *ref) {
     bool success=false;
     value cutoff; 
+    value box;
 
     ref->cutoff=(objectinstance_getproperty(self, pairwise_cutoffproperty, &cutoff) && 
                  morpho_valuetofloat(cutoff, &ref->cutoffdist));
+    ref->periodic=(objectinstance_getproperty(self, pairwise_periodicproperty, &box) && 
+                 morpho_valuetofloat(box, &ref->box));
 
     if (objectinstance_getproperty(self, pairwise_potentialproperty, &ref->potential) && 
         MORPHO_ISOBJECT(ref->potential) && 
@@ -146,6 +220,9 @@ bool pairwise_integrand(vm *v, objectmesh *mesh, elementid id, int nv, int *vid,
         // Compute separation
         matrix_getcolumn(mesh->vert, j, &x1);
         functional_vecsub(mesh->dim, x0, x1, s);
+        if (eref->periodic) {
+            functional_vecsub_periodic(mesh->dim, x0, x1, eref->box, s);
+        }
         double r = functional_vecnorm(mesh->dim, s);
 
         if (eref->cutoff && r > eref->cutoffdist) continue; 
@@ -175,6 +252,9 @@ bool pairwise_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, 
         // Compute separation
         matrix_getcolumn(mesh->vert, j, &x1);
         functional_vecsub(mesh->dim, x0, x1, s);
+        if (eref->periodic) {
+            functional_vecsub_periodic(mesh->dim, x0, x1, eref->box, s);
+        }
         double r = functional_vecnorm(mesh->dim, s);
 
         if (eref->cutoff && r > eref->cutoffdist) continue; 
@@ -199,11 +279,13 @@ value Pairwise_init(vm *v, int nargs, value *args) {
     objectinstance *self = MORPHO_GETINSTANCE(MORPHO_SELF(args));
     int nfixed=nargs; 
     value cutoff = MORPHO_NIL;
+    value box = MORPHO_NIL;
 
-    if (builtin_options(v, nargs, args, &nfixed, 1, pairwise_cutoffproperty, &cutoff) && 
+    if (builtin_options(v, nargs, args, &nfixed, 2, pairwise_cutoffproperty, &cutoff, pairwise_periodicproperty, &box) && 
         nfixed>0 && MORPHO_ISOBJECT(MORPHO_GETARG(args, 0))) {
         objectinstance_setproperty(self, pairwise_potentialproperty, MORPHO_GETARG(args, 0));
         objectinstance_setproperty(self, pairwise_cutoffproperty, cutoff);
+        objectinstance_setproperty(self, pairwise_periodicproperty, box);
     } else {
         morpho_runtimeerror(v, PAIRWISE_PRP);
     }
@@ -243,7 +325,9 @@ MORPHO_ENDCLASS
 void pairwise_initialize(void) { 
     pairwise_potentialproperty=builtin_internsymbolascstring(PAIRWISE_POTENTIAL_PROPERTY);
     pairwise_cutoffproperty=builtin_internsymbolascstring(PAIRWISE_CUTOFF_PROPERTY);
+    pairwise_periodicproperty=builtin_internsymbolascstring(PAIRWISE_PERIODIC_PROPERTY);
     pairwise_sigmaproperty=builtin_internsymbolascstring(PAIRWISE_SIGMA_PROPERTY);
+    lj_sigmaproperty=builtin_internsymbolascstring(LJ_SIGMA_PROPERTY);
 
     pairwise_valuemethod=builtin_internsymbolascstring(PAIRWISE_VALUE_METHOD);
     pairwise_derivativemethod=builtin_internsymbolascstring(PAIRWISE_DERIVATIVE_METHOD);
@@ -254,6 +338,7 @@ void pairwise_initialize(void) {
 
     builtin_addclass(COULOMB_CLASSNAME, MORPHO_GETCLASSDEFINITION(Coulomb), objclass);
     builtin_addclass(HERTZIAN_CLASSNAME, MORPHO_GETCLASSDEFINITION(Hertzian), objclass);
+    builtin_addclass(LENNARDJONES_CLASSNAME, MORPHO_GETCLASSDEFINITION(LennardJones), objclass);
 
     morpho_defineerror(PAIRWISE_PRP, ERROR_HALT, PAIRWISE_PRP_MSG);
 }

--- a/src/pairwise.h
+++ b/src/pairwise.h
@@ -6,15 +6,20 @@
 
 #define PAIRWISE_POTENTIAL_PROPERTY          "potential"
 #define PAIRWISE_CUTOFF_PROPERTY             "cutoff"
+#define PAIRWISE_PERIODIC_PROPERTY           "box"
 #define PAIRWISE_SIGMA_PROPERTY              "sigma"
+#define LJ_SIGMA_PROPERTY                    "sigma"
 
 #define COULOMB_CLASSNAME                    "CoulombPotential"
 #define HERTZIAN_CLASSNAME                   "HertzianPotential"
+#define LENNARDJONES_CLASSNAME               "LJPotential"
 
 #define PAIRWISE_VALUE_METHOD                "value"
 #define PAIRWISE_DERIVATIVE_METHOD           "derivative"
 
 #define PAIRWISE_PRP                         "PrwsPrp"
 #define PAIRWISE_PRP_MSG                     "Pairwise properties."
+
+void functional_vecsub_periodic(unsigned int n, double *a, double *b, double box, double *out);
 
 void pairwise_initialize(void);

--- a/test/lennardjones.morpho
+++ b/test/lennardjones.morpho
@@ -1,0 +1,18 @@
+import pairwise
+import meshtools 
+
+var mb = MeshBuilder() 
+mb.addvertex([0,0,0])
+var x = 1.3 // Random x position
+mb.addvertex([x,0,0])
+var m = mb.build() 
+
+var sigma = 1.0
+var lj = LJPotential(sigma) 
+
+var lp = Pairwise(lj, cutoff=2)
+
+var v = 4*((sigma/x)^12-(sigma/x)^6)
+var vprime = -24 * ((2 * (sigma/x)^12) - (sigma/x)^6) / x
+print (lp.integrand(m).column(1)[0]-v) < 10^(-10) // expect: true
+print (lp.gradient(m).column(1)[0]-vprime) < 10^(-10) // expect: true

--- a/test/testperiodic.morpho
+++ b/test/testperiodic.morpho
@@ -1,0 +1,27 @@
+import pairwise
+import meshtools 
+
+var c = CoulombPotential() 
+
+var lp = Pairwise(CoulombPotential(), box=1) // This sets a box of side length 1 centered at the origin
+
+var mb = MeshBuilder() 
+mb.addvertex([0.0,0,0])
+mb.addvertex([0.2,0,0])
+var m = mb.build() 
+
+print lp.integrand(m) // expect: [ 0 5 ]
+print lp.gradient(m) // expect: [ 25 -25 ]
+// expect: [ 0 0 ]
+// expect: [ 0 0 ]
+
+m.setvertexposition(1, Matrix([0.6, 0, 0])) // This vertex is now at a distance 0.4 to the *left* of the first vertex
+print lp.integrand(m) // expect: [ 0 2.5 ]
+print lp.gradient(m) // expect: [ -6.25 6.25 ]
+// expect: [ 0 0 ]
+// expect: [ 0 0 ]
+m.setvertexposition(1, Matrix([-1.9, 0, 0])) // This vertex is now at a distance 0.1 to the right of the first vertex
+print lp.integrand(m) // expect: [ 0 10 ]
+print lp.gradient(m) // expect: [ 100 -100 ]
+// expect: [ 0 0 ]
+// expect: [ 0 0 ]


### PR DESCRIPTION
This PR adds the Lennard Jones pairwise potential (`LJPotential`) to the pairwise module. 

In addition, it sets up an initial framework for periodic boundary conditions, with a cubic box currently implemented. This can be called for by initializing a `Pairwise` like so:
```
var lp = Pairwise(CoulombPotential(), box=1) // This sets a box of side length 1 centered at the origin
```
Tests are added. 

I didn't know how to accept a `Matrix` or a `List` input for `Pairwise` in order to pass in a general cuboid, but this is a start.